### PR TITLE
Handle leftover time in generated VO2max and anaerobic workouts

### DIFF
--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -245,6 +245,17 @@ function generateVO2MaxSteps(ftp: number, duration: number): Step[] {
     intervalCount++;
   }
 
+  // If there's time left that wasn't enough for a full interval
+  // add one final work step to use the remaining minutes
+  if (remaining > 0) {
+    steps.push({
+      minutes: remaining,
+      intensity: intensity,
+      description: `Final VO2max interval - give it your all`,
+      phase: "work",
+    });
+  }
+
   return steps;
 }
 
@@ -277,6 +288,16 @@ function generateAnaerobicSteps(ftp: number, duration: number): Step[] {
       remaining -= restDuration;
     }
     intervalCount++;
+  }
+
+  // Include any leftover time as a final anaerobic effort
+  if (remaining > 0) {
+    steps.push({
+      minutes: remaining,
+      intensity: intensity,
+      description: `Final anaerobic effort - all out`,
+      phase: "work",
+    });
   }
 
   return steps;


### PR DESCRIPTION
## Summary
- ensure VO2max workouts add a final interval when leftover minutes remain
- use any remaining time as a last anaerobic effort

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ed2bf548330b7c1919cf09e0550