### PR TITLE
Handle leftover VO2max interval time

### DIFF
--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -224,10 +224,10 @@ function generateVO2MaxSteps(ftp: number, duration: number): Step[] {
   let remaining = duration;
   let intervalCount = 1;
 
-  while (remaining > workDuration) {
+  while (remaining >= workDuration) {
     steps.push({
       minutes: workDuration,
-      intensity: intensity,
+      intensity,
       description: `VO2max interval ${intervalCount} - high intensity effort`,
       phase: "work",
     });
@@ -245,12 +245,10 @@ function generateVO2MaxSteps(ftp: number, duration: number): Step[] {
     intervalCount++;
   }
 
-  // If there's time left that wasn't enough for a full interval
-  // add one final work step to use the remaining minutes
   if (remaining > 0) {
     steps.push({
       minutes: remaining,
-      intensity: intensity,
+      intensity,
       description: `Final VO2max interval - give it your all`,
       phase: "work",
     });


### PR DESCRIPTION
## Summary
- Ensure VO2max interval generation consumes all available time
- Run remaining minutes as a final VO2max effort

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ac7aeab33c8330b47d8cf1b7076e6b