### PR TITLE
Use static patterns for workout generator

### DIFF
--- a/src/lib/generator.test.ts
+++ b/src/lib/generator.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { generateWorkout } from "./generator";
-import { generateVO2MaxSteps } from "./generator";
 
 describe("generateWorkout", () => {
   it("total step minutes should equal requested duration", () => {
@@ -8,15 +7,30 @@ describe("generateWorkout", () => {
     const total = workout.steps.reduce((sum, step) => sum + step.minutes, 0);
     expect(total).toBe(30);
   });
-});
 
-describe("generateVO2MaxSteps", () => {
-  it("includes final interval when duration is not multiple of 3", () => {
-    const steps = generateVO2MaxSteps(250, 10);
-    const total = steps.reduce((sum, step) => sum + step.minutes, 0);
-    expect(total).toBe(10);
-    const lastStep = steps[steps.length - 1];
-    expect(lastStep.phase).toBe("work");
-    expect(lastStep.minutes).toBe(1);
+  it("repeats pattern blocks and truncates final block", () => {
+    const ftp = 200;
+    const workout = generateWorkout({ ftp, durationMin: 60, type: "tempo" });
+
+    // remove warm-up and cool-down
+    const coreSteps = workout.steps.slice(1, -1);
+
+    // first step comes from tempo pattern (15 min at 85% FTP)
+    expect(coreSteps[0]).toMatchObject({
+      minutes: 15,
+      intensity: Math.round(ftp * 0.85),
+      phase: "work",
+    });
+
+    // last step should be truncated to fit duration
+    const lastStep = coreSteps[coreSteps.length - 1];
+    expect(lastStep.minutes).toBe(13);
+
+    // ensure no step shorter than 1 minute
+    expect(coreSteps.every((s) => s.minutes >= 1)).toBe(true);
+
+    // total minutes equals requested duration
+    const total = workout.steps.reduce((sum, step) => sum + step.minutes, 0);
+    expect(total).toBe(60);
   });
 });

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -1,3 +1,4 @@
+import { PATTERNS } from "./patterns";
 import { Step, Workout, WorkoutFormData } from "./types";
 
 export function generateWorkout({
@@ -5,23 +6,16 @@ export function generateWorkout({
   durationMin,
   type,
 }: WorkoutFormData): Workout {
-  // Apply difficulty modifiers
   const adjustedFtp = ftp;
 
-  // Calculate warm-up and cool-down durations
-  const warmupDuration = Math.max(
-    5,
-    Math.min(12, Math.floor(durationMin * 0.1))
-  );
-  const cooldownDuration = Math.max(
-    5,
-    Math.min(8, Math.floor(durationMin * 0.1))
-  );
-  const availableWorkTime = durationMin - warmupDuration - cooldownDuration;
+  // Warm-up and cool-down durations (~10% each)
+  const warmupDuration = Math.max(5, Math.min(12, Math.floor(durationMin * 0.1)));
+  const cooldownDuration = Math.max(5, Math.min(8, Math.floor(durationMin * 0.1)));
+  const coreDuration = durationMin - warmupDuration - cooldownDuration;
 
   const steps: Step[] = [];
 
-  // Add warm-up
+  // Warm-up step
   steps.push({
     minutes: warmupDuration,
     intensity: Math.round(adjustedFtp * 0.6),
@@ -29,40 +23,35 @@ export function generateWorkout({
     phase: "warmup",
   });
 
-  // Generate core workout based on type
-  let workSteps: Step[] = [];
-  let remainingTime = availableWorkTime;
-
-  switch (type) {
-    case "recovery":
-      workSteps = generateRecoverySteps(adjustedFtp, remainingTime);
+  // Core workout from static patterns
+  const pattern = PATTERNS[type];
+  const coreSteps: Step[] = [];
+  let remaining = coreDuration;
+  let index = 0;
+  while (remaining > 0) {
+    const block = pattern[index % pattern.length];
+    const blockMinutes = Math.max(1, block.minutes);
+    let minutes = Math.min(blockMinutes, remaining);
+    if (minutes < 1) {
+      // roll leftover time into previous step to avoid very short blocks
+      if (coreSteps.length) {
+        coreSteps[coreSteps.length - 1].minutes += remaining;
+      }
+      remaining = 0;
       break;
-    case "endurance":
-      workSteps = generateEnduranceSteps(adjustedFtp, remainingTime);
-      break;
-    case "tempo":
-      workSteps = generateTempoSteps(adjustedFtp, remainingTime);
-      break;
-    case "threshold":
-      workSteps = generateThresholdSteps(adjustedFtp, remainingTime);
-      break;
-    case "vo2max":
-      workSteps = generateVO2MaxSteps(adjustedFtp, remainingTime);
-      break;
-    case "anaerobic":
-      workSteps = generateAnaerobicSteps(adjustedFtp, remainingTime);
-      break;
+    }
+    coreSteps.push({
+      minutes,
+      intensity: Math.round((block.intensityPct / 100) * ftp),
+      description: block.description + (minutes < blockMinutes ? " (truncated)" : ""),
+      phase: block.phase,
+    });
+    remaining -= minutes;
+    index++;
   }
+  steps.push(...coreSteps);
 
-  // Check if we need to truncate
-  const totalWorkTime = workSteps.reduce((sum, step) => sum + step.minutes, 0);
-  if (totalWorkTime > remainingTime) {
-    workSteps = truncateWorkSteps(workSteps, remainingTime);
-  }
-
-  steps.push(...workSteps);
-
-  // Add cool-down
+  // Cool-down step
   steps.push({
     minutes: cooldownDuration,
     intensity: Math.round(adjustedFtp * 0.5),
@@ -71,10 +60,10 @@ export function generateWorkout({
   });
 
   const totalMinutes = steps.reduce((sum, step) => sum + step.minutes, 0);
-  const workMinutes = workSteps
+  const workMinutes = coreSteps
     .filter((step) => step.phase === "work")
     .reduce((sum, step) => sum + step.minutes, 0);
-  const recoveryMinutes = workSteps
+  const recoveryMinutes = coreSteps
     .filter((step) => step.phase === "recovery")
     .reduce((sum, step) => sum + step.minutes, 0);
   const avgIntensity = Math.round(
@@ -82,7 +71,6 @@ export function generateWorkout({
       totalMinutes
   );
 
-  // Format title with proper capitalization
   const typeTitle =
     type === "vo2max" ? "VO2max" : type.charAt(0).toUpperCase() + type.slice(1);
 
@@ -95,232 +83,4 @@ export function generateWorkout({
     recoveryMinutes,
     avgIntensity,
   };
-}
-
-function generateRecoverySteps(ftp: number, duration: number): Step[] {
-  return [
-    {
-      minutes: duration,
-      intensity: Math.round(ftp * 0.55),
-      description: "Continuous easy pace for active recovery",
-      phase: "work",
-    },
-  ];
-}
-
-function generateEnduranceSteps(ftp: number, duration: number): Step[] {
-  const steps: Step[] = [];
-  const chunkDuration = 10;
-  const intensity = Math.round(ftp * 0.7);
-
-  let remaining = duration;
-  while (remaining > 0) {
-    const stepDuration = Math.min(chunkDuration, remaining);
-    steps.push({
-      minutes: stepDuration,
-      intensity: intensity,
-      description: "Steady aerobic pace for base building",
-      phase: "work",
-    });
-    remaining -= stepDuration;
-  }
-
-  return steps;
-}
-
-function generateTempoSteps(ftp: number, duration: number): Step[] {
-  const steps: Step[] = [];
-  const workDuration = 10;
-  const restDuration = 3;
-  const intensity = Math.round(ftp * 0.83);
-  const restIntensity = Math.round(ftp * 0.55);
-
-  let remaining = duration;
-  let intervalCount = 1;
-
-  while (remaining > workDuration) {
-    steps.push({
-      minutes: workDuration,
-      intensity: intensity,
-      description: `Tempo effort ${intervalCount} - moderately hard sustainable pace`,
-      phase: "work",
-    });
-    remaining -= workDuration;
-
-    if (remaining > restDuration) {
-      steps.push({
-        minutes: restDuration,
-        intensity: restIntensity,
-        description: "Easy recovery between tempo efforts",
-        phase: "recovery",
-      });
-      remaining -= restDuration;
-    }
-    intervalCount++;
-  }
-
-  if (remaining > 0) {
-    steps.push({
-      minutes: remaining,
-      intensity: intensity,
-      description: `Final tempo effort - maintain steady power`,
-      phase: "work",
-    });
-  }
-
-  return steps;
-}
-
-function generateThresholdSteps(ftp: number, duration: number): Step[] {
-  const steps: Step[] = [];
-  const workDuration = 8;
-  const restDuration = 4;
-  const intensity = Math.round(ftp * 1.0);
-  const restIntensity = Math.round(ftp * 0.55);
-
-  let remaining = duration;
-  let intervalCount = 1;
-
-  while (remaining > workDuration) {
-    steps.push({
-      minutes: workDuration,
-      intensity: intensity,
-      description: `Threshold effort ${intervalCount} - sustainable but challenging`,
-      phase: "work",
-    });
-    remaining -= workDuration;
-
-    if (remaining > restDuration) {
-      steps.push({
-        minutes: restDuration,
-        intensity: restIntensity,
-        description: "Easy recovery between threshold efforts",
-        phase: "recovery",
-      });
-      remaining -= restDuration;
-    }
-    intervalCount++;
-  }
-
-  if (remaining > 0) {
-    steps.push({
-      minutes: remaining,
-      intensity: intensity,
-      description: `Final threshold effort - push through fatigue`,
-      phase: "work",
-    });
-  }
-
-  return steps;
-}
-
-export function generateVO2MaxSteps(ftp: number, duration: number): Step[] {
-  const steps: Step[] = [];
-  const workDuration = 3;
-  const restDuration = workDuration; // Equal rest
-  const intensity = Math.round(ftp * 1.15);
-  const restIntensity = Math.round(ftp * 0.55);
-
-  let remaining = duration;
-  let intervalCount = 1;
-
-  while (remaining >= workDuration) {
-    steps.push({
-      minutes: workDuration,
-      intensity,
-      description: `VO2max interval ${intervalCount} - high intensity effort`,
-      phase: "work",
-    });
-    remaining -= workDuration;
-
-    if (remaining > restDuration) {
-      steps.push({
-        minutes: restDuration,
-        intensity: restIntensity,
-        description: "Recovery between VO2max intervals",
-        phase: "recovery",
-      });
-      remaining -= restDuration;
-    }
-    intervalCount++;
-  }
-
-  if (remaining > 0) {
-    steps.push({
-      minutes: remaining,
-      intensity,
-      description: `Final VO2max interval - give it your all`,
-      phase: "work",
-    });
-  }
-
-  return steps;
-}
-
-function generateAnaerobicSteps(ftp: number, duration: number): Step[] {
-  const steps: Step[] = [];
-  const workDuration = 1; // 1 minute for MVP (keeping integers)
-  const restDuration = 2;
-  const intensity = Math.round(ftp * 1.35);
-  const restIntensity = Math.round(ftp * 0.55);
-
-  let remaining = duration;
-  let intervalCount = 1;
-
-  while (remaining > workDuration) {
-    steps.push({
-      minutes: workDuration,
-      intensity: intensity,
-      description: `Anaerobic effort ${intervalCount} - very high intensity`,
-      phase: "work",
-    });
-    remaining -= workDuration;
-
-    if (remaining > restDuration) {
-      steps.push({
-        minutes: restDuration,
-        intensity: restIntensity,
-        description: "Recovery between anaerobic efforts",
-        phase: "recovery",
-      });
-      remaining -= restDuration;
-    }
-    intervalCount++;
-  }
-
-  // Include any leftover time as a final anaerobic effort
-  if (remaining > 0) {
-    steps.push({
-      minutes: remaining,
-      intensity: intensity,
-      description: `Final anaerobic effort - all out`,
-      phase: "work",
-    });
-  }
-
-  return steps;
-}
-
-function truncateWorkSteps(steps: Step[], maxDuration: number): Step[] {
-  const truncatedSteps: Step[] = [];
-  let currentDuration = 0;
-
-  for (const step of steps) {
-    if (currentDuration + step.minutes <= maxDuration) {
-      truncatedSteps.push(step);
-      currentDuration += step.minutes;
-    } else {
-      const remainingTime = maxDuration - currentDuration;
-      if (remainingTime > 0) {
-        truncatedSteps.push({
-          ...step,
-          minutes: remainingTime,
-          description: step.description + " (truncated)",
-        });
-      }
-      break;
-    }
-  }
-
-  return truncatedSteps;
 }


### PR DESCRIPTION
## Summary
- Replace bespoke step generators with pattern-driven workflow using `PATTERNS`
- Convert pattern intensity percentages to FTP-based watts and prevent sub‑minute steps
- Add tests for pattern repetition, truncation, and overall duration

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8e38fcbc8330b5791208d3ff333b