### PR TITLE
Handle short workout durations and prevent zero-minute steps

### DIFF
--- a/src/lib/generator.test.ts
+++ b/src/lib/generator.test.ts
@@ -33,4 +33,19 @@ describe("generateWorkout", () => {
     const total = workout.steps.reduce((sum, step) => sum + step.minutes, 0);
     expect(total).toBe(60);
   });
+
+  it("returns warm-up and cool-down with hint for durations < 10", () => {
+    const workout = generateWorkout({ ftp: 250, durationMin: 5, type: "recovery" });
+    expect(workout.steps).toHaveLength(2);
+    expect(workout.steps[0].phase).toBe("warmup");
+    expect(workout.steps[1].phase).toBe("cooldown");
+    expect(workout.totalMinutes).toBe(10);
+    expect(workout.hint).toBe("Increase duration to generate a complete workout");
+    expect(workout.steps.every((s) => s.minutes > 0)).toBe(true);
+  });
+
+  it("never produces steps with 0 minutes", () => {
+    const workout = generateWorkout({ ftp: 250, durationMin: 20, type: "tempo" });
+    expect(workout.steps.every((s) => s.minutes > 0)).toBe(true);
+  });
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,7 @@ export type Workout = {
   workMinutes?: number;
   recoveryMinutes?: number;
   avgIntensity?: number;
+  hint?: string;
 };
 
 export interface WorkoutFormData {


### PR DESCRIPTION
## Summary
- validate workout generation duration and return only warm-up/cool-down with hint when requested time is under 10 minutes
- filter steps to eliminate zero-minute entries and compute metrics from sanitized steps
- extend workout type and tests to cover short duration edge cases

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada1b6461c8330b753415faaea4610