### PR TITLE
feat: avoid immediate variant repeats

### DIFF
--- a/__tests__/generator.random.test.ts
+++ b/__tests__/generator.random.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateWorkout } from "@/lib/generator";
+
+describe("generateWorkout randomization", () => {
+  it("returns same workout when only one variant fits", () => {
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0);
+    const first = generateWorkout({
+      ftp: 250,
+      type: "tempo",
+      durationRange: "60-75",
+    });
+    expect(first).not.toBeNull();
+    const second = generateWorkout(
+      { ftp: 250, type: "tempo", durationRange: "60-75" },
+      first!.signature
+    );
+    expect(second).not.toBeNull();
+    expect(second!.signature).toBe(first!.signature);
+    spy.mockRestore();
+  });
+
+  it("avoids immediate repeat when two variants fit", () => {
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0);
+    const first = generateWorkout({
+      ftp: 250,
+      type: "tempo",
+      durationRange: "45-60",
+    });
+    expect(first).not.toBeNull();
+    const second = generateWorkout(
+      { ftp: 250, type: "tempo", durationRange: "45-60" },
+      first!.signature
+    );
+    expect(second).not.toBeNull();
+    expect(second!.signature).not.toBe(first!.signature);
+    spy.mockRestore();
+  });
+
+  it("rotates through multiple variants without immediate repetition", () => {
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0);
+    const one = generateWorkout({
+      ftp: 250,
+      type: "recovery",
+      durationRange: "30-45",
+    });
+    const two = generateWorkout(
+      { ftp: 250, type: "recovery", durationRange: "30-45" },
+      one!.signature
+    );
+    const three = generateWorkout(
+      { ftp: 250, type: "recovery", durationRange: "30-45" },
+      two!.signature
+    );
+    expect(one).not.toBeNull();
+    expect(two).not.toBeNull();
+    expect(three).not.toBeNull();
+    expect(two!.signature).not.toBe(one!.signature);
+    expect(three!.signature).not.toBe(two!.signature);
+    expect(three!.signature).toBe(one!.signature);
+    spy.mockRestore();
+  });
+});
+

--- a/src/components/WorkoutForm.tsx
+++ b/src/components/WorkoutForm.tsx
@@ -52,6 +52,7 @@ interface WorkoutFormProps {
 
 export function WorkoutForm({ onWorkoutGenerated }: WorkoutFormProps) {
   const [isGenerating, setIsGenerating] = useState(false);
+  const [lastSignature, setLastSignature] = useState<string | undefined>();
 
   const form = useForm<WorkoutFormData>({
     resolver: zodResolver(formSchema),
@@ -60,6 +61,7 @@ export function WorkoutForm({ onWorkoutGenerated }: WorkoutFormProps) {
   });
 
   const ftp = form.watch("ftp");
+  const typeWatch = form.watch("type");
 
   // Load persisted/URL params on mount and sync FTP changes across tabs
   useEffect(() => {
@@ -122,7 +124,7 @@ export function WorkoutForm({ onWorkoutGenerated }: WorkoutFormProps) {
   const onSubmit = async (data: WorkoutFormData) => {
     setIsGenerating(true);
     try {
-      const workout = generateWorkout(data);
+      const workout = generateWorkout(data, lastSignature);
       if (typeof window !== "undefined") {
         const url = new URL(window.location.href);
         setParam(url, "ftp", data.ftp);
@@ -130,12 +132,17 @@ export function WorkoutForm({ onWorkoutGenerated }: WorkoutFormProps) {
         setParam(url, "type", data.type);
       }
       onWorkoutGenerated(workout);
+      setLastSignature(workout?.signature);
     } catch (error) {
       console.error("Error generating workout:", error);
     } finally {
       setIsGenerating(false);
     }
   };
+
+  useEffect(() => {
+    setLastSignature(undefined);
+  }, [typeWatch]);
 
   return (
     <div className="rounded-2xl bg-[--card] border border-[--border] p-6 shadow-[--shadow-card]">

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -1,0 +1,24 @@
+import { Step } from "./types";
+
+/**
+ * Create a unique runtime signature for a sequence of steps.
+ * The signature uses minutes, intensity (or from/to if a ramp), and phase.
+ * It's intended only for in-memory comparison of variants.
+ */
+export function makeSignature(steps: Step[]): string {
+  return steps
+    .map((s) => {
+      const parts: (string | number)[] = [s.minutes];
+      const anyStep = s as any;
+      if (typeof anyStep.intensity === "number") {
+        parts.push(anyStep.intensity);
+      } else {
+        if (typeof anyStep.from === "number") parts.push(anyStep.from);
+        if (typeof anyStep.to === "number") parts.push(anyStep.to);
+      }
+      if (s.phase) parts.push(s.phase);
+      return parts.join(":");
+    })
+    .join("|");
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,7 @@ export type Workout = {
   recoveryMinutes?: number;
   avgIntensity?: number;
   hint?: string;
+  signature: string;
 };
 
 export type DurationRangeValue =

--- a/tests/export.test.tsx
+++ b/tests/export.test.tsx
@@ -21,6 +21,7 @@ const sampleWorkout: Workout = {
   workMinutes: 5,
   recoveryMinutes: 0,
   avgIntensity: 120,
+  signature: "sig",
 };
 
 afterEach(() => {

--- a/tests/zwo.test.ts
+++ b/tests/zwo.test.ts
@@ -16,6 +16,7 @@ const workout: Workout = {
   workMinutes: 15,
   recoveryMinutes: 0,
   avgIntensity: 230,
+  signature: "sig",
 };
 
 describe("toZwoXml", () => {


### PR DESCRIPTION
## Summary
- add runtime signatures to workout steps
- random generator rotates among variants without repeating previous
- store last signature in UI to prevent consecutive repeats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbc4ba94b48330b562d67420c4acf7