### PR TITLE
feat: add ramp step support with bias and exports

### DIFF
--- a/src/components/WorkoutChart.test.tsx
+++ b/src/components/WorkoutChart.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { WorkoutChart } from "./WorkoutChart";
+import type { Step } from "@/lib/types";
+
+describe("WorkoutChart", () => {
+  it("draws polygons for ramps and rectangles for steady steps", () => {
+    const steps: Step[] = [
+      {
+        kind: "ramp",
+        minutes: 5,
+        from: 100,
+        to: 200,
+        phase: "warmup",
+        description: "WU",
+      },
+      {
+        kind: "steady",
+        minutes: 10,
+        intensity: 150,
+        phase: "work",
+        description: "Work",
+      },
+    ];
+    render(<WorkoutChart steps={steps} ftp={200} biasPct={110} />);
+    const ramp = screen.getByTestId("step-0");
+    const steady = screen.getByTestId("step-1");
+    expect(ramp.tagName.toLowerCase()).toBe("polygon");
+    expect(steady.tagName.toLowerCase()).toBe("rect");
+    expect(ramp.getAttribute("points")).toBe("0,400 0,290 50,180 50,400");
+    expect(steady.getAttribute("x")).toBe("50");
+    expect(steady.getAttribute("y")).toBe("235");
+    expect(steady.getAttribute("height")).toBe("165");
+  });
+});

--- a/src/components/WorkoutChart.tsx
+++ b/src/components/WorkoutChart.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { Step } from "@/lib/types";
+import { applyBias } from "./WorkoutOutput";
+
+interface WorkoutChartProps {
+  steps: Step[];
+  ftp: number;
+  biasPct: number;
+}
+
+const getZoneColor = (watts: number, ftp: number): string => {
+  if (ftp <= 0) return "var(--z1)";
+  const pct = (watts / ftp) * 100;
+  if (pct <= 60) return "var(--z1)";
+  if (pct <= 75) return "var(--z2)";
+  if (pct <= 90) return "var(--z3)";
+  if (pct <= 105) return "var(--z4)";
+  return "var(--z5)";
+};
+
+export function WorkoutChart({ steps, ftp, biasPct }: WorkoutChartProps) {
+  const totalMinutes = steps.reduce((sum, s) => sum + s.minutes, 0);
+  const xScale = 10;
+  const width = totalMinutes * xScale;
+  const height = ftp * 2;
+
+  let x = 0;
+
+  return (
+    <svg width={width} height={height} data-testid="workout-chart">
+      {steps.map((s, i) => {
+        const w = s.minutes * xScale;
+        if ("kind" in s && s.kind === "ramp") {
+          const from = applyBias(s.from, biasPct);
+          const to = applyBias(s.to, biasPct);
+          const points = `${x},${height} ${x},${height - from} ${x + w},${
+            height - to
+          } ${x + w},${height}`;
+          const color = getZoneColor((from + to) / 2, ftp);
+          const el = (
+            <polygon
+              key={i}
+              points={points}
+              fill={color}
+              data-testid={`step-${i}`}
+            >
+              <title>{`${s.minutes}' — ramp ${from}→${to} W — ${s.description}`}</title>
+            </polygon>
+          );
+          x += w;
+          return el;
+        } else {
+          const intensity = applyBias((s as any).intensity, biasPct);
+          const color = getZoneColor(intensity, ftp);
+          const el = (
+            <rect
+              key={i}
+              x={x}
+              y={height - intensity}
+              width={w}
+              height={intensity}
+              fill={color}
+              data-testid={`step-${i}`}
+            >
+              <title>{`${s.minutes}' — ${intensity} W — ${s.description}`}</title>
+            </rect>
+          );
+          x += w;
+          return el;
+        }
+      })}
+    </svg>
+  );
+}
+
+export default WorkoutChart;

--- a/src/components/WorkoutOutput.bias.test.tsx
+++ b/src/components/WorkoutOutput.bias.test.tsx
@@ -12,4 +12,11 @@ describe("bias helpers", () => {
     expect(applyBias(-100, 80)).toBe(0);
     expect(applyBias(200, 80)).toBe(160);
   });
+
+  it("applies bias uniformly to ramp endpoints", () => {
+    const from = applyBias(100, 110);
+    const to = applyBias(200, 110);
+    expect(from).toBe(110);
+    expect(to).toBe(220);
+  });
 });

--- a/src/components/WorkoutOutput.export.test.tsx
+++ b/src/components/WorkoutOutput.export.test.tsx
@@ -19,14 +19,34 @@ const sampleWorkout: Workout = {
   title: "Test Workout",
   ftp: 200,
   steps: [
-    { minutes: 5, intensity: 120, description: "Warmup", phase: "warmup" },
-    { minutes: 5, intensity: 150, description: "Work", phase: "work" },
-    { minutes: 5, intensity: 100, description: "Cooldown", phase: "cooldown" },
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 100,
+      to: 120,
+      description: "Warmup",
+      phase: "warmup",
+    },
+    {
+      kind: "steady",
+      minutes: 5,
+      intensity: 150,
+      description: "Work",
+      phase: "work",
+    },
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 120,
+      to: 100,
+      description: "Cooldown",
+      phase: "cooldown",
+    },
   ],
   totalMinutes: 15,
   workMinutes: 5,
   recoveryMinutes: 0,
-  avgIntensity: 120,
+  avgIntensity: 123,
 };
 
 afterEach(() => {

--- a/src/lib/generator.test.ts
+++ b/src/lib/generator.test.ts
@@ -8,6 +8,26 @@ describe("generateWorkout", () => {
     expect(total).toBe(30);
   });
 
+  it("creates ramp steps for warm-up and cool-down with correct targets", () => {
+    const ftp = 200;
+    const workout = generateWorkout({ ftp, durationMin: 40, type: "endurance" });
+    const warm = workout.steps[0];
+    const cool = workout.steps[workout.steps.length - 1];
+    expect((warm as any).kind).toBe("ramp");
+    expect((cool as any).kind).toBe("ramp");
+    expect((warm as any).from).toBe(Math.round(ftp * 0.5));
+    expect((warm as any).to).toBe(Math.round(ftp * 0.6));
+    expect((cool as any).from).toBe(Math.round(ftp * 0.6));
+    expect((cool as any).to).toBe(Math.round(ftp * 0.5));
+  });
+
+  it("computes avg intensity using ramp averages", () => {
+    const ftp = 200;
+    const w = generateWorkout({ ftp, durationMin: 9, type: "recovery" });
+    expect(w.steps).toHaveLength(2); // only warmup/cooldown
+    expect(w.avgIntensity).toBe(110);
+  });
+
   it("repeats chosen variant and shortens final block when needed", () => {
     const ftp = 200;
     const spy = vi.spyOn(Math, "random").mockReturnValue(0); // pick variant A

--- a/src/lib/signature.test.ts
+++ b/src/lib/signature.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { getSignature } from "./signature";
+import type { Workout } from "./types";
+
+describe("getSignature", () => {
+  it("includes ramp and steady steps", () => {
+    const workout: Workout = {
+      title: "Sig",
+      ftp: 200,
+      steps: [
+        {
+          kind: "ramp",
+          minutes: 5,
+          from: 100,
+          to: 120,
+          description: "WU",
+          phase: "warmup",
+        },
+        {
+          kind: "steady",
+          minutes: 10,
+          intensity: 150,
+          description: "Work",
+          phase: "work",
+        },
+      ],
+      totalMinutes: 15,
+      workMinutes: 10,
+      recoveryMinutes: 0,
+      avgIntensity: 130,
+    };
+    expect(getSignature(workout)).toBe("r:5:100:120:warmup|s:10:150:work");
+  });
+});

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -1,0 +1,13 @@
+import type { Workout } from "./types";
+
+export function getSignature(workout: Workout): string {
+  return workout.steps
+    .map((s) => {
+      if ("kind" in s && s.kind === "ramp") {
+        return `r:${s.minutes}:${s.from}:${s.to}:${s.phase}`;
+      }
+      const intensity = (s as any).intensity;
+      return `s:${s.minutes}:${intensity}:${s.phase}`;
+    })
+    .join("|");
+}

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expectTypeOf } from "vitest";
+import type { Step, SteadyStep, RampStep } from "./types";
+
+describe("Step types", () => {
+  it("supports steady and ramp steps and legacy steady", () => {
+    const steady: SteadyStep = {
+      kind: "steady",
+      minutes: 5,
+      intensity: 200,
+      phase: "work",
+      description: "",
+    };
+    const ramp: RampStep = {
+      kind: "ramp",
+      minutes: 5,
+      from: 100,
+      to: 150,
+      phase: "warmup",
+      description: "",
+    };
+    const legacy: Step = {
+      minutes: 5,
+      intensity: 180,
+      phase: "work",
+      description: "legacy",
+    };
+    const steps: Step[] = [steady, ramp, legacy];
+    expectTypeOf(steps[0]).toMatchTypeOf<Step>();
+    expectTypeOf(steps[1]).toMatchTypeOf<Step>();
+    expectTypeOf(steps[2]).toMatchTypeOf<Step>();
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,12 +53,35 @@ export const WORKOUT_TYPES = {
   },
 };
 
-export type Step = {
+export type StepPhase = "warmup" | "work" | "recovery" | "cooldown";
+
+export type SteadyStep = {
+  kind: "steady";
   minutes: number;
   intensity: number;
+  phase: StepPhase;
   description: string;
-  phase?: "warmup" | "work" | "recovery" | "cooldown";
 };
+
+export type RampStep = {
+  kind: "ramp";
+  minutes: number;
+  from: number;
+  to: number;
+  phase: Extract<StepPhase, "warmup" | "cooldown">;
+  description: string;
+};
+
+// Legacy steady steps may omit the "kind" property. Treat them as steady.
+export type LegacySteadyStep = {
+  minutes: number;
+  intensity: number;
+  phase?: StepPhase;
+  description: string;
+  kind?: undefined;
+};
+
+export type Step = SteadyStep | RampStep | LegacySteadyStep;
 
 export type Workout = {
   title: string;

--- a/src/lib/zwo.ts
+++ b/src/lib/zwo.ts
@@ -31,10 +31,20 @@ export function toZwoXml(
 
   for (const step of workout.steps) {
     const duration = Math.floor(step.minutes * 60);
-    const ratioRaw = workout.ftp > 0 ? step.intensity / workout.ftp : 0;
-    const ratioClamped = clamp(ratioRaw, 0.3, 1.6);
-    const power = ratioClamped.toFixed(2);
-    parts.push(`    <SteadyState Duration="${duration}" Power="${power}" />`);
+    if ((step as any).kind === "ramp") {
+      const fromRatio = workout.ftp > 0 ? (step as any).from / workout.ftp : 0;
+      const toRatio = workout.ftp > 0 ? (step as any).to / workout.ftp : 0;
+      const low = clamp(fromRatio, 0.3, 1.6).toFixed(2);
+      const high = clamp(toRatio, 0.3, 1.6).toFixed(2);
+      parts.push(
+        `    <Ramp Duration="${duration}" PowerLow="${low}" PowerHigh="${high}" />`
+      );
+    } else {
+      const ratioRaw = workout.ftp > 0 ? (step as any).intensity / workout.ftp : 0;
+      const ratioClamped = clamp(ratioRaw, 0.3, 1.6);
+      const power = ratioClamped.toFixed(2);
+      parts.push(`    <SteadyState Duration="${duration}" Power="${power}" />`);
+    }
   }
 
   parts.push(`  </workout>`);

--- a/tests/zwo.test.ts
+++ b/tests/zwo.test.ts
@@ -7,10 +7,36 @@ const workout: Workout = {
   title: "Zwift Export <Test>",
   ftp: 250,
   steps: [
-    { minutes: 5, intensity: 100, description: "Warmup", phase: "warmup" }, // 100/250=0.40
-    { minutes: 10, intensity: 300, description: "Work 1", phase: "work" }, // 300/250=1.20
-    { minutes: 5, intensity: 500, description: "Work 2", phase: "work" }, // 500/250=2.00 -> 1.60 (clamp)
-    { minutes: 5, intensity: 50, description: "Cooldown", phase: "cooldown" }, // 50/250=0.20 -> 0.30 (clamp)
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 100,
+      to: 150,
+      description: "Warmup",
+      phase: "warmup",
+    }, // 100→150
+    {
+      kind: "steady",
+      minutes: 10,
+      intensity: 300,
+      description: "Work 1",
+      phase: "work",
+    }, // 300/250=1.20
+    {
+      kind: "steady",
+      minutes: 5,
+      intensity: 500,
+      description: "Work 2",
+      phase: "work",
+    }, // 500/250=2.00 -> 1.60 (clamp)
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 150,
+      to: 100,
+      description: "Cooldown",
+      phase: "cooldown",
+    }, // 150→100
   ],
   totalMinutes: 25,
   workMinutes: 15,
@@ -28,18 +54,19 @@ describe("toZwoXml", () => {
     expect(xml).toContain('<description>FTP 250W • Bias 100%</description>');
   });
 
-  it("creates one SteadyState per step with floored duration and clamped 2-decimal power", () => {
+  it("creates proper blocks with floored duration and clamped 2-decimal power", () => {
     const xml = toZwoXml({ ...workout, biasPct: 100 });
 
-    // 4 steps -> 4 blocks
-    const matches = xml.match(/<SteadyState\s/g) || [];
-    expect(matches.length).toBe(workout.steps.length);
+    // 4 steps -> 4 blocks (2 Ramp + 2 SteadyState)
+    const steady = xml.match(/<SteadyState\s/g) || [];
+    const ramps = xml.match(/<Ramp\s/g) || [];
+    expect(steady.length + ramps.length).toBe(workout.steps.length);
 
-    // Duration check (floor(minutes*60))
-    expect(xml).toContain('Duration="300" Power="0.40"'); // 5' warmup
-    expect(xml).toContain('Duration="600" Power="1.20"'); // 10' work 1
-    expect(xml).toContain('Duration="300" Power="1.60"'); // 5' work 2 clamped down from 2.00
-    expect(xml).toContain('Duration="300" Power="0.30"'); // 5' cooldown clamped up from 0.20
+    // Duration and power checks
+    expect(xml).toContain('Duration="300" PowerLow="0.40" PowerHigh="0.60"'); // warmup ramp
+    expect(xml).toContain('Duration="600" Power="1.20"'); // work 1
+    expect(xml).toContain('Duration="300" Power="1.60"'); // work 2 clamped
+    expect(xml).toContain('Duration="300" PowerLow="0.60" PowerHigh="0.40"'); // cooldown ramp
 
     // No NaN/undefined strings
     expect(xml.includes('NaN')).toBe(false);
@@ -50,11 +77,11 @@ describe("toZwoXml", () => {
     const xml = toZwoXml({ ...workout });
     const parser = new DOMParser();
     const doc = parser.parseFromString(xml, 'application/xml');
-    const nodes = doc.querySelectorAll('SteadyState');
+    const nodes = doc.querySelectorAll('SteadyState, Ramp');
     expect(nodes.length).toBe(workout.steps.length);
     const first = nodes[0] as Element;
     expect(first.getAttribute('Duration')).toBe('300');
-    expect(first.getAttribute('Power')).toBe('0.40');
+    expect(first.tagName).toBe('Ramp');
   });
 });
 


### PR DESCRIPTION
## Summary
- add ramp step type and legacy steady support
- generate warm-up and cool-down ramps with bias-aware chart and output
- extend exports, signature, and tests for ramp steps

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d0569bc83308bee32cbfecebbaa