### PR TITLE
feat: add ramp step type and exports

### DIFF
--- a/__tests__/generator.test.ts
+++ b/__tests__/generator.test.ts
@@ -6,7 +6,9 @@ describe("generateWorkout", () => {
     expect(result).not.toBeNull();
     const workout = result!;
     expect(workout.steps[0].phase).toBe("warmup");
+    expect((workout.steps[0] as any).kind).toBe("ramp");
     expect(workout.steps[workout.steps.length - 1].phase).toBe("cooldown");
+    expect((workout.steps[workout.steps.length - 1] as any).kind).toBe("ramp");
     expect(workout.steps.length).toBeGreaterThanOrEqual(3);
 
     const totalMinutes = workout.steps.reduce((sum, s) => sum + s.minutes, 0);
@@ -23,7 +25,13 @@ describe("generateWorkout", () => {
     expect(workout.recoveryMinutes).toBe(recoveryMinutes);
 
     const avgIntensity = Math.round(
-      workout.steps.reduce((sum, s) => sum + s.intensity * s.minutes, 0) / totalMinutes
+      workout.steps.reduce((sum, s) => {
+        const kind = (s as any).kind ?? "steady";
+        if (kind === "ramp") {
+          return sum + ((s as any).from + (s as any).to) / 2 * s.minutes;
+        }
+        return sum + (s as any).intensity * s.minutes;
+      }, 0) / totalMinutes
     );
     expect(workout.avgIntensity).toBe(avgIntensity);
   });

--- a/__tests__/types.test.ts
+++ b/__tests__/types.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import type { RampStep, SteadyStep, Step } from "@/lib/types";
+
+describe("Step type definitions", () => {
+  it("accepts steady and ramp steps", () => {
+    const steady: SteadyStep = {
+      kind: "steady",
+      minutes: 5,
+      intensity: 200,
+      description: "steady",
+      phase: "work",
+    };
+    const ramp: RampStep = {
+      kind: "ramp",
+      minutes: 5,
+      from: 100,
+      to: 150,
+      description: "ramp",
+      phase: "warmup",
+    };
+    const steps: Step[] = [steady, ramp];
+    expect(steps.length).toBe(2);
+  });
+});

--- a/src/components/WorkoutChart.tsx
+++ b/src/components/WorkoutChart.tsx
@@ -1,14 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-
-export type StepLike = {
-  minutes: number;
-  intensity: number; // watts (bias already applied upstream)
-  description: string;
-  phase?: "warmup" | "cooldown" | "work" | "recovery";
-};
+import type { Step } from "@/lib/types";
 
 interface Props {
-  steps: StepLike[];
+  steps: Step[];
   ftp: number;
 }
 
@@ -16,17 +10,21 @@ const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(ma
 
 // Visual/geometry constants
 const MAX_PERC = 1.6; // 160% FTP = full height
-const RAMP_OUTER_FACTOR = 0.6; // outer side as a fraction of target height
 const GAP_PCT = 0.6; // horizontal gap between bars (percentage of total width)
 const CORNER_RADIUS = 2; // rounded corners radius for bars
 const V_PAD = 6; // vertical padding inside SVG (percentage of viewBox height)
 
-function colorForStep(step: StepLike, ftp: number) {
+function colorForStep(step: Step, ftp: number) {
   if (step.phase === "warmup") return "var(--phase-warmup)";
   if (step.phase === "cooldown") return "var(--phase-cooldown)";
 
   if (ftp <= 0) return "var(--z1)";
-  const pct = (step.intensity / ftp) * 100;
+  const kind = (step as any).kind ?? "steady";
+  const watts =
+    kind === "ramp"
+      ? (((step as any).from + (step as any).to) / 2)
+      : (step as any).intensity;
+  const pct = (watts / ftp) * 100;
   if (pct <= 60) return "var(--z1)";
   if (pct <= 75) return "var(--z2)";
   if (pct <= 90) return "var(--z3)";
@@ -34,21 +32,18 @@ function colorForStep(step: StepLike, ftp: number) {
   return "var(--z5)";
 }
 
-type BarShape = "rect" | "ramp-up" | "ramp-down";
+type BarShape = "rect" | "trapezoid";
 type BarGeom = {
   x: number;
   y: number;
   w: number;
   h: number;
-  s: StepLike;
+  s: Step;
   shape: BarShape;
   topY: number;
   yStart: number;
   yEnd: number;
 };
-
-const shapeForPhase = (phase?: StepLike["phase"]): BarShape =>
-  phase === "warmup" ? "ramp-up" : phase === "cooldown" ? "ramp-down" : "rect";
 
 const heightPct = (watts: number, ftp: number): number => {
   if (ftp <= 0) return 0;
@@ -184,30 +179,33 @@ export function WorkoutChart({ steps, ftp }: Props) {
     for (let i = 0; i < steps.length; i++) {
       const s = steps[i];
       const w = totalMinutes > 0 ? (s.minutes / totalMinutes) * available : 0;
-      const innerH = heightPct(s.intensity, ftp); // biased intensity already applied upstream
-      const outerH = innerH * RAMP_OUTER_FACTOR;
+      const kind = (s as any).kind ?? "steady";
 
-      const x = xCursor;
-      const shape = shapeForPhase(s.phase);
+      let h = 0;
+      let y = 0;
+      let yStart = 0;
+      let yEnd = 0;
+      let shape: BarShape = "rect";
 
-      // Default rectangle metrics (work/recovery blocks)
-      let h = innerH;
-      let y = 100 - h;
-      let yStart = 100 - innerH; // top at left
-      let yEnd = 100 - innerH; // top at right
-
-      if (shape === "ramp-up") {
-        // Warmup: ramp from a fraction of target height to full target height
-        yStart = 100 - outerH;
-        yEnd = 100 - innerH;
-      } else if (shape === "ramp-down") {
-        // Cooldown: ramp from full target height down to its fraction
-        yStart = 100 - innerH;
-        yEnd = 100 - outerH;
+      if (kind === "ramp") {
+        const fromH = heightPct((s as any).from, ftp);
+        const toH = heightPct((s as any).to, ftp);
+        h = Math.max(fromH, toH);
+        y = 100 - h;
+        yStart = 100 - fromH;
+        yEnd = 100 - toH;
+        shape = "trapezoid";
+      } else {
+        const intH = heightPct((s as any).intensity, ftp);
+        h = intH;
+        y = 100 - h;
+        yStart = 100 - intH;
+        yEnd = 100 - intH;
+        shape = "rect";
       }
 
       const topY = Math.min(yStart, yEnd); // highest point for tooltip positioning
-      out.push({ x, y, w, h, s, shape, topY, yStart, yEnd });
+      out.push({ x: xCursor, y, w, h, s, shape, topY, yStart, yEnd });
 
       // advance cursor; add gap after every bar except the last
       xCursor += w + (i < steps.length - 1 ? GAP_PCT : 0);
@@ -268,58 +266,70 @@ export function WorkoutChart({ steps, ftp }: Props) {
         <rect x={0} y={0} width={100} height={100} fill="transparent" />
         <g transform={`translate(0, ${vPad}) scale(1, ${scaleY})`}>
           {bars.map((bar, idx) => {
-          const fill = colorForStep(bar.s, ftp);
-          const activate = () => {
-            setActive(idx);
-            updateTooltipForIndex(idx);
-          };
-          const clear = () => setActive(null);
-          const isActive = active === idx;
-          if (bar.shape === "rect") {
-            return (
-              <g key={idx}>
-                <rect
-                  x={bar.x}
-                  y={bar.y}
-                  width={Math.max(0.001, bar.w)}
-                  height={bar.h}
-                  rx={CORNER_RADIUS}
-                  style={{ fill }}
-                  stroke={isActive ? "var(--ring)" : "transparent"}
-                  strokeWidth={isActive ? 1.5 : 0}
-                  role="button"
-                  tabIndex={0}
-                  aria-label={`${bar.s.minutes}' • ${bar.s.intensity} W — ${bar.s.description}`}
-                  onFocus={activate}
-                  onBlur={clear}
-                  onMouseEnter={activate}
-                  onMouseLeave={clear}
-                />
-              </g>
-            );
-          }
+            const fill = colorForStep(bar.s, ftp);
+            const activate = () => {
+              setActive(idx);
+              updateTooltipForIndex(idx);
+            };
+            const clear = () => setActive(null);
+            const isActive = active === idx;
+            const kind = (bar.s as any).kind ?? "steady";
+            const wattsText =
+              kind === "ramp"
+                ? `ramp ${(bar.s as any).from}→${(bar.s as any).to} W`
+                : `${(bar.s as any).intensity} W`;
+            const label = `${bar.s.minutes}' • ${wattsText} — ${bar.s.description}`;
+            if (bar.shape === "rect") {
+              return (
+                <g key={idx}>
+                  <rect
+                    x={bar.x}
+                    y={bar.y}
+                    width={Math.max(0.001, bar.w)}
+                    height={bar.h}
+                    rx={CORNER_RADIUS}
+                    style={{ fill }}
+                    stroke={isActive ? "var(--ring)" : "transparent"}
+                    strokeWidth={isActive ? 1.5 : 0}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={label}
+                    onFocus={activate}
+                    onBlur={clear}
+                    onMouseEnter={activate}
+                    onMouseLeave={clear}
+                  />
+                </g>
+              );
+            }
 
-          // Right-angled trapezoids for warmup/cooldown (rounded corners)
-          const x0 = bar.x;
-          const x1 = bar.x + Math.max(0.001, bar.w);
-          const yBase = 100; // bottom baseline
-          const d = roundedTrapezoidPath(x0, x1, yBase, bar.yStart, bar.yEnd, CORNER_RADIUS);
-          return (
-            <path
-              key={idx}
-              d={d}
-              style={{ fill }}
-              stroke={isActive ? "var(--ring)" : "transparent"}
-              strokeWidth={isActive ? 1.5 : 0}
-              role="button"
-              tabIndex={0}
-              aria-label={`${bar.s.minutes}' • ${bar.s.intensity} W — ${bar.s.description}`}
-              onFocus={activate}
-              onBlur={clear}
-              onMouseEnter={activate}
-              onMouseLeave={clear}
-            />
-          );
+            const x0 = bar.x;
+            const x1 = bar.x + Math.max(0.001, bar.w);
+            const yBase = 100; // bottom baseline
+            const d = roundedTrapezoidPath(
+              x0,
+              x1,
+              yBase,
+              bar.yStart,
+              bar.yEnd,
+              CORNER_RADIUS
+            );
+            return (
+              <path
+                key={idx}
+                d={d}
+                style={{ fill }}
+                stroke={isActive ? "var(--ring)" : "transparent"}
+                strokeWidth={isActive ? 1.5 : 0}
+                role="button"
+                tabIndex={0}
+                aria-label={label}
+                onFocus={activate}
+                onBlur={clear}
+                onMouseEnter={activate}
+                onMouseLeave={clear}
+              />
+            );
           })}
         </g>
       </svg>
@@ -330,8 +340,20 @@ export function WorkoutChart({ steps, ftp }: Props) {
           className="pointer-events-none absolute z-10 bg-[--card] text-[--text-primary] border border-[--border] shadow-sm rounded-md px-2 py-1 text-xs tabular-nums whitespace-nowrap"
           style={{ left: `${tooltipPos.left}px`, top: `${tooltipPos.top}px` }}
         >
-          <div className="font-semibold">{`${steps[active].minutes}' • ${steps[active].intensity} W`}</div>
-          <div className="text-[--text-secondary]">{steps[active].description}</div>
+          {(() => {
+            const step = steps[active];
+            const kind = (step as any).kind ?? "steady";
+            const wattsText =
+              kind === "ramp"
+                ? `ramp ${(step as any).from}→${(step as any).to} W`
+                : `${(step as any).intensity} W`;
+            return (
+              <>
+                <div className="font-semibold">{`${step.minutes}' • ${wattsText}`}</div>
+                <div className="text-[--text-secondary]">{step.description}</div>
+              </>
+            );
+          })()}
         </div>
       )}
     </div>

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -8,16 +8,13 @@ import { Step } from "./types";
 export function makeSignature(steps: Step[]): string {
   return steps
     .map((s) => {
-      const parts: (string | number)[] = [s.minutes];
-      const anyStep = s as any;
-      if (typeof anyStep.intensity === "number") {
-        parts.push(anyStep.intensity);
-      } else {
-        if (typeof anyStep.from === "number") parts.push(anyStep.from);
-        if (typeof anyStep.to === "number") parts.push(anyStep.to);
+      const kind = (s as any).kind ?? "steady";
+      if (kind === "ramp") {
+        const rs = s as any;
+        return `r:${rs.minutes}:${rs.from}:${rs.to}${rs.phase ? `:${rs.phase}` : ""}`;
       }
-      if (s.phase) parts.push(s.phase);
-      return parts.join(":");
+      const ss = s as any;
+      return `s:${ss.minutes}:${ss.intensity}${ss.phase ? `:${ss.phase}` : ""}`;
     })
     .join("|");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,12 +53,26 @@ export const WORKOUT_TYPES = {
   },
 };
 
-export type Step = {
+export type StepPhase = "warmup" | "work" | "recovery" | "cooldown";
+
+export type SteadyStep = {
+  kind: "steady";
   minutes: number;
   intensity: number;
+  phase: StepPhase;
   description: string;
-  phase?: "warmup" | "work" | "recovery" | "cooldown";
 };
+
+export type RampStep = {
+  kind: "ramp";
+  minutes: number;
+  from: number;
+  to: number;
+  phase: Extract<StepPhase, "warmup" | "cooldown">;
+  description: string;
+};
+
+export type Step = SteadyStep | RampStep;
 
 export type Workout = {
   title: string;

--- a/src/lib/zwo.ts
+++ b/src/lib/zwo.ts
@@ -30,11 +30,22 @@ export function toZwoXml(
   parts.push(`  <workout>`);
 
   for (const step of workout.steps) {
+    const kind = (step as any).kind ?? "steady";
     const duration = Math.floor(step.minutes * 60);
-    const ratioRaw = workout.ftp > 0 ? step.intensity / workout.ftp : 0;
-    const ratioClamped = clamp(ratioRaw, 0.3, 1.6);
-    const power = ratioClamped.toFixed(2);
-    parts.push(`    <SteadyState Duration="${duration}" Power="${power}" />`);
+    if (kind === "ramp") {
+      const fromRatio = workout.ftp > 0 ? (step as any).from / workout.ftp : 0;
+      const toRatio = workout.ftp > 0 ? (step as any).to / workout.ftp : 0;
+      const low = clamp(fromRatio, 0.3, 1.6).toFixed(2);
+      const high = clamp(toRatio, 0.3, 1.6).toFixed(2);
+      parts.push(
+        `    <Ramp Duration="${duration}" PowerLow="${low}" PowerHigh="${high}" />`
+      );
+    } else {
+      const ratioRaw = workout.ftp > 0 ? (step as any).intensity / workout.ftp : 0;
+      const ratioClamped = clamp(ratioRaw, 0.3, 1.6);
+      const power = ratioClamped.toFixed(2);
+      parts.push(`    <SteadyState Duration="${duration}" Power="${power}" />`);
+    }
   }
 
   parts.push(`  </workout>`);

--- a/tests/chart.test.tsx
+++ b/tests/chart.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import WorkoutChart from "@/components/WorkoutChart";
+import type { Step } from "@/lib/types";
+
+describe("WorkoutChart", () => {
+  it("renders steady rectangles and ramp trapezoids", () => {
+    const steps: Step[] = [
+      { kind: "steady", minutes: 5, intensity: 100, description: "steady", phase: "work" },
+      { kind: "ramp", minutes: 5, from: 80, to: 120, description: "ramp", phase: "warmup" },
+    ];
+    render(<WorkoutChart steps={steps} ftp={200} />);
+    const rect = screen.getByLabelText("5' • 100 W — steady");
+    expect(rect.tagName.toLowerCase()).toBe("rect");
+    const path = screen.getByLabelText("5' • ramp 80→120 W — ramp");
+    expect(path.tagName.toLowerCase()).toBe("path");
+  });
+});

--- a/tests/export.test.tsx
+++ b/tests/export.test.tsx
@@ -13,14 +13,34 @@ const sampleWorkout: Workout = {
   title: "Test Workout",
   ftp: 200,
   steps: [
-    { minutes: 5, intensity: 120, description: "Warmup", phase: "warmup" },
-    { minutes: 5, intensity: 150, description: "Work", phase: "work" },
-    { minutes: 5, intensity: 100, description: "Cooldown", phase: "cooldown" },
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 100,
+      to: 120,
+      description: "Warmup",
+      phase: "warmup",
+    },
+    {
+      kind: "steady",
+      minutes: 5,
+      intensity: 150,
+      description: "Work",
+      phase: "work",
+    },
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 120,
+      to: 100,
+      description: "Cooldown",
+      phase: "cooldown",
+    },
   ],
   totalMinutes: 15,
   workMinutes: 5,
   recoveryMinutes: 0,
-  avgIntensity: 120,
+  avgIntensity: 123,
   signature: "sig",
 };
 
@@ -65,6 +85,9 @@ describe("Export actions", () => {
     const jsonParts = blobSpy.mock.calls[0][0] as any[];
     const jsonStr = String(jsonParts[0]);
     expect(jsonStr).toContain("\"biasPct\": 100");
+    expect(jsonStr).toContain('"kind": "ramp"');
+    expect(jsonStr).toContain('"from": 100');
+    expect(jsonStr).toContain('"to": 120');
     expect(clickedDownloads).toContain("Test_Workout_bias_100.json");
 
     // Text
@@ -73,6 +96,7 @@ describe("Export actions", () => {
     const textStr = String(textParts[0]);
     expect(textStr).toContain("FTP: 200 W");
     expect(textStr).toContain("Bias: 100%");
+    expect(textStr).toContain("ramp 100→120 W");
     expect(clickedDownloads).toContain("Test_Workout.txt");
 
     // ZWO

--- a/tests/signature.test.ts
+++ b/tests/signature.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { makeSignature } from "@/lib/signature";
+import type { Step } from "@/lib/types";
+
+describe("makeSignature", () => {
+  it("includes ramp and steady markers", () => {
+    const steps: Step[] = [
+      { kind: "steady", minutes: 5, intensity: 200, description: "s", phase: "work" },
+      { kind: "ramp", minutes: 10, from: 100, to: 150, description: "r", phase: "warmup" },
+    ];
+    expect(makeSignature(steps)).toBe("s:5:200:work|r:10:100:150:warmup");
+  });
+});


### PR DESCRIPTION
## Summary
- add typed steady/ramp step union with warm-up and cool-down ramps
- render ramp steps as trapezoids with bias-aware tooltips
- extend exports, signature, and tests for ramp support

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bc2fb0b2248330be75999b4e9969bc