### PR TITLE
feat: add ramp step type and exports

### DIFF
--- a/__tests__/generator.test.ts
+++ b/__tests__/generator.test.ts
@@ -6,7 +6,9 @@ describe("generateWorkout", () => {
     expect(result).not.toBeNull();
     const workout = result!;
     expect(workout.steps[0].phase).toBe("warmup");
+    expect((workout.steps[0] as any).kind).toBe("ramp");
     expect(workout.steps[workout.steps.length - 1].phase).toBe("cooldown");
+    expect((workout.steps[workout.steps.length - 1] as any).kind).toBe("ramp");
     expect(workout.steps.length).toBeGreaterThanOrEqual(3);
 
     const totalMinutes = workout.steps.reduce((sum, s) => sum + s.minutes, 0);
@@ -23,7 +25,13 @@ describe("generateWorkout", () => {
     expect(workout.recoveryMinutes).toBe(recoveryMinutes);
 
     const avgIntensity = Math.round(
-      workout.steps.reduce((sum, s) => sum + s.intensity * s.minutes, 0) / totalMinutes
+      workout.steps.reduce((sum, s) => {
+        const kind = (s as any).kind ?? "steady";
+        if (kind === "ramp") {
+          return sum + ((s as any).from + (s as any).to) / 2 * s.minutes;
+        }
+        return sum + (s as any).intensity * s.minutes;
+      }, 0) / totalMinutes
     );
     expect(workout.avgIntensity).toBe(avgIntensity);
   });

--- a/__tests__/types.test.ts
+++ b/__tests__/types.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import type { RampStep, SteadyStep, Step } from "@/lib/types";
+
+describe("Step type definitions", () => {
+  it("accepts steady and ramp steps", () => {
+    const steady: SteadyStep = {
+      kind: "steady",
+      minutes: 5,
+      intensity: 200,
+      description: "steady",
+      phase: "work",
+    };
+    const ramp: RampStep = {
+      kind: "ramp",
+      minutes: 5,
+      from: 100,
+      to: 150,
+      description: "ramp",
+      phase: "warmup",
+    };
+    const steps: Step[] = [steady, ramp];
+    expect(steps.length).toBe(2);
+  });
+});

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -8,16 +8,13 @@ import { Step } from "./types";
 export function makeSignature(steps: Step[]): string {
   return steps
     .map((s) => {
-      const parts: (string | number)[] = [s.minutes];
-      const anyStep = s as any;
-      if (typeof anyStep.intensity === "number") {
-        parts.push(anyStep.intensity);
-      } else {
-        if (typeof anyStep.from === "number") parts.push(anyStep.from);
-        if (typeof anyStep.to === "number") parts.push(anyStep.to);
+      const kind = (s as any).kind ?? "steady";
+      if (kind === "ramp") {
+        const rs = s as any;
+        return `r:${rs.minutes}:${rs.from}:${rs.to}${rs.phase ? `:${rs.phase}` : ""}`;
       }
-      if (s.phase) parts.push(s.phase);
-      return parts.join(":");
+      const ss = s as any;
+      return `s:${ss.minutes}:${ss.intensity}${ss.phase ? `:${ss.phase}` : ""}`;
     })
     .join("|");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,12 +53,26 @@ export const WORKOUT_TYPES = {
   },
 };
 
-export type Step = {
+export type StepPhase = "warmup" | "work" | "recovery" | "cooldown";
+
+export type SteadyStep = {
+  kind: "steady";
   minutes: number;
   intensity: number;
+  phase: StepPhase;
   description: string;
-  phase?: "warmup" | "work" | "recovery" | "cooldown";
 };
+
+export type RampStep = {
+  kind: "ramp";
+  minutes: number;
+  from: number;
+  to: number;
+  phase: Extract<StepPhase, "warmup" | "cooldown">;
+  description: string;
+};
+
+export type Step = SteadyStep | RampStep;
 
 export type Workout = {
   title: string;

--- a/src/lib/zwo.ts
+++ b/src/lib/zwo.ts
@@ -30,11 +30,22 @@ export function toZwoXml(
   parts.push(`  <workout>`);
 
   for (const step of workout.steps) {
+    const kind = (step as any).kind ?? "steady";
     const duration = Math.floor(step.minutes * 60);
-    const ratioRaw = workout.ftp > 0 ? step.intensity / workout.ftp : 0;
-    const ratioClamped = clamp(ratioRaw, 0.3, 1.6);
-    const power = ratioClamped.toFixed(2);
-    parts.push(`    <SteadyState Duration="${duration}" Power="${power}" />`);
+    if (kind === "ramp") {
+      const fromRatio = workout.ftp > 0 ? (step as any).from / workout.ftp : 0;
+      const toRatio = workout.ftp > 0 ? (step as any).to / workout.ftp : 0;
+      const low = clamp(fromRatio, 0.3, 1.6).toFixed(2);
+      const high = clamp(toRatio, 0.3, 1.6).toFixed(2);
+      parts.push(
+        `    <Ramp Duration="${duration}" PowerLow="${low}" PowerHigh="${high}" />`
+      );
+    } else {
+      const ratioRaw = workout.ftp > 0 ? (step as any).intensity / workout.ftp : 0;
+      const ratioClamped = clamp(ratioRaw, 0.3, 1.6);
+      const power = ratioClamped.toFixed(2);
+      parts.push(`    <SteadyState Duration="${duration}" Power="${power}" />`);
+    }
   }
 
   parts.push(`  </workout>`);

--- a/tests/chart.test.tsx
+++ b/tests/chart.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import WorkoutChart from "@/components/WorkoutChart";
+import type { Step } from "@/lib/types";
+
+describe("WorkoutChart", () => {
+  it("renders steady rectangles and ramp trapezoids", () => {
+    const steps: Step[] = [
+      { kind: "steady", minutes: 5, intensity: 100, description: "steady", phase: "work" },
+      { kind: "ramp", minutes: 5, from: 80, to: 120, description: "ramp", phase: "warmup" },
+    ];
+    render(<WorkoutChart steps={steps} ftp={200} />);
+    const rect = screen.getByLabelText("5' • 100 W — steady");
+    expect(rect.tagName.toLowerCase()).toBe("rect");
+    const path = screen.getByLabelText("5' • ramp 80→120 W — ramp");
+    expect(path.tagName.toLowerCase()).toBe("path");
+  });
+
+  it("colors warm-up ramps grey and core ramps by zone", () => {
+    const steps: Step[] = [
+      { kind: "ramp", minutes: 5, from: 80, to: 120, description: "wu", phase: "warmup" },
+      { kind: "ramp", minutes: 5, from: 140, to: 200, description: "core", phase: "work" },
+    ];
+    render(<WorkoutChart steps={steps} ftp={200} />);
+    const wu = screen.getByLabelText("5' • ramp 80→120 W — wu");
+    expect(wu.getAttribute("style")).toContain("var(--phase-warmup)");
+    const core = screen.getByLabelText("5' • ramp 140→200 W — core");
+    expect(core.getAttribute("style")).toContain("var(--z3)");
+  });
+});

--- a/tests/export.test.tsx
+++ b/tests/export.test.tsx
@@ -13,14 +13,34 @@ const sampleWorkout: Workout = {
   title: "Test Workout",
   ftp: 200,
   steps: [
-    { minutes: 5, intensity: 120, description: "Warmup", phase: "warmup" },
-    { minutes: 5, intensity: 150, description: "Work", phase: "work" },
-    { minutes: 5, intensity: 100, description: "Cooldown", phase: "cooldown" },
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 100,
+      to: 120,
+      description: "Warmup",
+      phase: "warmup",
+    },
+    {
+      kind: "steady",
+      minutes: 5,
+      intensity: 150,
+      description: "Work",
+      phase: "work",
+    },
+    {
+      kind: "ramp",
+      minutes: 5,
+      from: 120,
+      to: 100,
+      description: "Cooldown",
+      phase: "cooldown",
+    },
   ],
   totalMinutes: 15,
   workMinutes: 5,
   recoveryMinutes: 0,
-  avgIntensity: 120,
+  avgIntensity: 123,
   signature: "sig",
 };
 
@@ -65,6 +85,9 @@ describe("Export actions", () => {
     const jsonParts = blobSpy.mock.calls[0][0] as any[];
     const jsonStr = String(jsonParts[0]);
     expect(jsonStr).toContain("\"biasPct\": 100");
+    expect(jsonStr).toContain('"kind": "ramp"');
+    expect(jsonStr).toContain('"from": 100');
+    expect(jsonStr).toContain('"to": 120');
     expect(clickedDownloads).toContain("Test_Workout_bias_100.json");
 
     // Text
@@ -73,6 +96,7 @@ describe("Export actions", () => {
     const textStr = String(textParts[0]);
     expect(textStr).toContain("FTP: 200 W");
     expect(textStr).toContain("Bias: 100%");
+    expect(textStr).toContain("ramp 100→120 W");
     expect(clickedDownloads).toContain("Test_Workout.txt");
 
     // ZWO

--- a/tests/signature.test.ts
+++ b/tests/signature.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { makeSignature } from "@/lib/signature";
+import type { Step } from "@/lib/types";
+
+describe("makeSignature", () => {
+  it("includes ramp and steady markers", () => {
+    const steps: Step[] = [
+      { kind: "steady", minutes: 5, intensity: 200, description: "s", phase: "work" },
+      { kind: "ramp", minutes: 10, from: 100, to: 150, description: "r", phase: "warmup" },
+    ];
+    expect(makeSignature(steps)).toBe("s:5:200:work|r:10:100:150:warmup");
+  });
+});


### PR DESCRIPTION
## Summary
- add typed steady/ramp step union with warm-up and cool-down ramps
- render ramp steps as trapezoids with bias-aware tooltips
- extend exports, signature, and tests for ramp support
- color core ramp blocks by their average biased zone while keeping warm-up/cool-down ramps grey

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bc2fb0b2248330be75999b4e9969bc