### PR TITLE
feat: scaffold Magic Rewriter ChatGPT App

### DIFF
--- a/magic-rewriter/README.md
+++ b/magic-rewriter/README.md
@@ -1,0 +1,13 @@
+# Magic Rewriter (ChatGPT App)
+GPT-native rewriting app built with ChatGPT Apps SDK.
+
+### Features
+- Rewrite text based on tone (Professional, Clear, Friendly)
+- Preserve meaning; no new facts or URLs
+- Fully GPT-native: no backend, storage, or telemetry
+- Accessible, minimal UI (official SDK components only)
+
+### TODO
+- Implement `runRewriteModel` using the official Apps SDK model invocation.
+- Connect clipboard helper if available.
+- Validate manifest and metadata for store submission.

--- a/magic-rewriter/app.json
+++ b/magic-rewriter/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "Magic Rewriter",
+  "tagline": "Rewrite any text in one click—professional, clear, or friendly.",
+  "description_short": "Rewrite any text while preserving meaning and tone.",
+  "description_long": "Magic Rewriter is a ChatGPT App that rewrites text to be professional, clear, or friendly—without adding facts or URLs. All processing happens inside ChatGPT. No external backend or storage.",
+  "icon": "icon.svg",
+  "categories": ["writing", "productivity"],
+  "examples": [
+    "Make this email sound more professional (keep meaning).",
+    "Simplify this text while keeping its meaning.",
+    "Rewrite this LinkedIn post in a friendlier tone.",
+    "Make this paragraph clearer and more concise.",
+    "Same meaning, more formal."
+  ],
+  "policy_notes": [
+    "No external storage.",
+    "No PII enrichment.",
+    "No added facts or URLs.",
+    "All runtime inside ChatGPT."
+  ]
+}

--- a/magic-rewriter/icon.svg
+++ b/magic-rewriter/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true">
+  <rect x="10" y="12" width="44" height="40" rx="6" />
+  <path d="M18 22h28M18 30h20M18 38h24" stroke="#fff" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/magic-rewriter/src/chatgpt-apps-ui.d.ts
+++ b/magic-rewriter/src/chatgpt-apps-ui.d.ts
@@ -1,0 +1,84 @@
+declare module "chatgpt-apps-ui" {
+  import type { ComponentType, ReactNode } from "react";
+
+  export type StatusState = "idle" | "processing" | "error" | string;
+
+  export interface FormValues {
+    [key: string]: unknown;
+  }
+
+  export interface FormContext {
+    setError(field: string, message: string): void;
+    setFormError(message: string): void;
+    setStatus(status: StatusState): void;
+    setValue(field: string, value: unknown): void;
+    getValue(field: string): unknown;
+    copyToClipboard(value: string): void;
+  }
+
+  export interface FormProps {
+    children?: ReactNode;
+    "aria-label"?: string;
+    onSubmit?: (values: FormValues, ctx: FormContext) => void | Promise<void>;
+  }
+
+  export const Form: ComponentType<FormProps>;
+
+  export interface FieldProps {
+    name: string;
+    label?: string;
+    children?: ReactNode;
+    "aria-label"?: string;
+    initialValue?: unknown;
+    placeholder?: string;
+    required?: boolean;
+    readOnly?: boolean;
+  }
+
+  export const Field: ComponentType<FieldProps>;
+
+  export interface TextAreaProps {
+    readOnly?: boolean;
+    maxLength?: number;
+    showCount?: boolean;
+    placeholder?: string;
+  }
+
+  export const TextArea: ComponentType<TextAreaProps>;
+
+  export interface SelectOption {
+    label: string;
+    value: string;
+  }
+
+  export interface SelectProps {
+    options: SelectOption[];
+  }
+
+  export const Select: ComponentType<SelectProps>;
+
+  export interface ButtonProps {
+    type?: "button" | "submit" | "reset";
+    children?: ReactNode;
+    "aria-label"?: string;
+    onClick?: (event: unknown, ctx: FormContext) => void | Promise<void>;
+  }
+
+  export const Button: ComponentType<ButtonProps>;
+
+  export interface CardProps {
+    children?: ReactNode;
+  }
+
+  export const Card: ComponentType<CardProps>;
+
+  export interface TextProps {
+    children?: ReactNode;
+    role?: string;
+    "aria-level"?: number;
+    size?: "xs" | "sm" | "md" | "lg" | string;
+    "aria-live"?: "off" | "polite" | "assertive";
+  }
+
+  export const Text: ComponentType<TextProps>;
+}

--- a/magic-rewriter/src/index.tsx
+++ b/magic-rewriter/src/index.tsx
@@ -1,0 +1,130 @@
+// ChatGPT Apps SDK UI — compliant starter.
+import {
+  Form,
+  Field,
+  TextArea,
+  Select,
+  Button,
+  Card,
+  Text,
+  type FormContext,
+  type FormValues,
+  type SelectOption
+} from "chatgpt-apps-ui";
+
+async function runRewriteModel(input: string, tone: string): Promise<string> {
+  // TODO(Apps SDK): Replace with official ai.run() call.
+  // Preserve meaning, no new facts or URLs, keep input language.
+  return "";
+}
+
+export default function App() {
+  const toneOptions: SelectOption[] = [
+    { label: "Professional", value: "Professional" },
+    { label: "Clear", value: "Clear" },
+    { label: "Friendly", value: "Friendly" }
+  ];
+
+  return (
+    <Form
+      aria-label="Magic Rewriter"
+      onSubmit={async (values: FormValues, ctx: FormContext) => {
+        const inputValue = values?.inputText;
+        const toneValue = values?.tone;
+        const input = typeof inputValue === "string" ? inputValue.trim() : "";
+        const tone = typeof toneValue === "string" && toneValue ? toneValue : "Professional";
+        if (!input) {
+          ctx.setError("inputText", "Text is required");
+          return;
+        }
+        ctx.setStatus("processing");
+        try {
+          const output = await runRewriteModel(input, tone);
+          ctx.setValue("outputText", output || "");
+          ctx.setStatus("idle");
+        } catch {
+          ctx.setFormError("An error occurred while rewriting.");
+          ctx.setStatus("error");
+        }
+      }}
+    >
+      <Card>
+        <Text role="heading" aria-level={1}>Magic Rewriter</Text>
+        <Text size="sm">Rewrite any text—professional, clear, or friendly. No added facts.</Text>
+      </Card>
+
+      <Field name="tone" label="Tone" aria-label="Select rewriting tone" initialValue="Professional">
+        <Select options={toneOptions} />
+      </Field>
+
+      <Field
+        name="inputText"
+        label="Source text"
+        aria-label="Source text to rewrite"
+        placeholder="Paste your text here…"
+        required
+      >
+        <TextArea maxLength={3000} showCount />
+      </Field>
+
+      <Card>
+        <Field name="outputText" label="Rewritten" aria-label="Rewritten result" readOnly>
+          <TextArea readOnly />
+        </Field>
+      </Card>
+
+      <Card>
+        <Button type="submit" aria-label="Rewrite">Rewrite</Button>
+        <Button
+          type="button"
+          aria-label="Regenerate"
+          onClick={async (_: unknown, ctx: FormContext) => {
+            const inputValue = ctx.getValue("inputText");
+            const toneValue = ctx.getValue("tone");
+            const input = typeof inputValue === "string" ? inputValue.trim() : "";
+            const tone = typeof toneValue === "string" && toneValue ? toneValue : "Professional";
+            if (!input) return;
+            ctx.setStatus("processing");
+            try {
+              const output = await runRewriteModel(input, tone);
+              ctx.setValue("outputText", output || "");
+              ctx.setStatus("idle");
+            } catch {
+              ctx.setFormError("An error occurred while regenerating.");
+              ctx.setStatus("error");
+            }
+          }}
+        >
+          Regenerate
+        </Button>
+        <Button
+          type="button"
+          aria-label="Copy"
+          onClick={(_: unknown, ctx: FormContext) => {
+            const textValue = ctx.getValue("outputText");
+            const textToCopy = typeof textValue === "string" ? textValue : "";
+            if (textToCopy) ctx.copyToClipboard(textToCopy);
+          }}
+        >
+          Copy
+        </Button>
+        <Button
+          type="button"
+          aria-label="Clear"
+          onClick={(_: unknown, ctx: FormContext) => {
+            ctx.setValue("inputText", "");
+            ctx.setValue("outputText", "");
+          }}
+        >
+          Clear
+        </Button>
+      </Card>
+
+      <Card>
+        <Text size="xs" aria-live="polite">
+          Notes: Preserves meaning, no added facts or URLs. Output stays in the input language.
+        </Text>
+      </Card>
+    </Form>
+  );
+}

--- a/magic-rewriter/src/prompt.ts
+++ b/magic-rewriter/src/prompt.ts
@@ -1,0 +1,13 @@
+export function buildRewritePrompt(input: string, tone: string) {
+  return {
+    system: [
+      "You are a rewriting assistant.",
+      "Preserve meaning.",
+      "Do not add facts or URLs not present in the input.",
+      "Keep the same language as the input.",
+      `Adjust the tone to: ${tone}.`,
+      "Output plain text only."
+    ].join(" "),
+    user: input
+  };
+}


### PR DESCRIPTION
## Summary
- add Magic Rewriter app manifest, icon, and README metadata
- scaffold GPT-native rewrite form with tone selection and output controls
- provide prompt builder and local UI module typings for ChatGPT Apps SDK primitives

## Testing
- node check-typescript.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e8dac4d7848330a69f00d1159095e7